### PR TITLE
Add Edit Session integration tools for MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ __`claude_desktop_config.json`__
 
 [See sample project](https://github.com/jasonjgardner/blockbench-mcp-project) for prompt examples.
 
+### Edit Session Integration
+
+The MCP server can hook into Blockbench's Edit Session feature to enable remote collaboration and automation. Edit Sessions use Peer.js to create P2P connections between Blockbench instances.
+
+**Available Edit Session Tools:**
+- `edit_session_start` - Start a new session as host
+- `edit_session_join` - Join an existing session with a token
+- `edit_session_status` - Get current session status
+- `edit_session_send_command` - Send commands (undo/redo/quit) to all clients
+- `edit_session_send_data` - Send custom data through the P2P connection
+- `edit_session_send_chat` - Send chat messages to session participants
+- `edit_session_quit` - Leave or close the session
+
+**Use Cases:**
+- Remote automation of collaborative modeling sessions
+- Programmatic control of multi-user workflows
+- Integration with external tools and CI/CD pipelines
+- Custom synchronization and data sharing between Blockbench instances
+
+See [docs/tools.md](docs/tools.md) for detailed documentation of all available tools.
+
 ## Plugin Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed instructions on setting up the development environment and how to add new tools, resources, and prompts.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -490,6 +490,81 @@ Fills and submits dialog forms programmatically.
 
 ---
 
+## Edit Session (Collaboration)
+
+### edit_session_start
+#### ⚠️ Experimental
+Starts a new Edit Session as the host, creating a P2P connection that other users can join.
+
+**Parameters:**
+- `username`: Optional username to use in the session (random name assigned if not provided)
+
+**Returns:** Session token that others can use to join, along with username and success status
+
+**Note:** Requires an open project. The session uses Peer.js to create a collaborative environment where multiple users can work on the same model simultaneously.
+
+### edit_session_join
+#### ⚠️ Experimental
+Joins an existing Edit Session using a token provided by the host.
+
+**Parameters:**
+- `token`: 16-character session token from the host
+- `username`: Optional username to use in the session
+
+**Returns:** Connection status, username, and session details
+
+**Note:** Connects as a client to the host's session. The host's model will be loaded into your Blockbench instance.
+
+### edit_session_status
+#### ⚠️ Experimental
+Gets the current status of the Edit Session.
+
+**Returns:** JSON object with:
+- `active`: Whether a session is active
+- `hosting`: Whether this instance is hosting
+- `client_count`: Number of connected clients
+- `token`: Session token (if hosting)
+- `username`: Current username
+- `has_project`: Whether a project is loaded
+
+### edit_session_send_command
+#### ⚠️ Experimental
+Sends a command through an active Edit Session to all connected clients.
+
+**Parameters:**
+- `command`: Command to send (undo/redo/quit_session)
+
+**Note:** Only the host can send commands. Commands are broadcast to all clients in the session.
+
+### edit_session_send_data
+#### ⚠️ Experimental
+Sends custom data through an active Edit Session with a specified type identifier.
+
+**Parameters:**
+- `type`: Type identifier for the data (e.g., 'custom_action', 'mcp_command')
+- `data`: JSON-serializable data payload (string, number, object, array, etc.)
+
+**Note:** Only the host can send data. Avoid using reserved type names: 'edit', 'init_model', 'command', 'chat_message', 'chat_input', 'client_count', 'change_project_meta'.
+
+**Use Case:** This tool allows the MCP server to emit custom commands through the Peer.js Edit Session connection, enabling external automation and control of collaborative sessions.
+
+### edit_session_send_chat
+#### ⚠️ Experimental
+Sends a chat message through the Edit Session visible to all connected clients.
+
+**Parameters:**
+- `message`: Chat message to send (max 512 characters)
+
+**Note:** Messages appear in the chat panel for all session participants.
+
+### edit_session_quit
+#### ⚠️ Experimental
+Quits the current Edit Session.
+
+**Note:** If hosting, this closes the session for all clients. If joined as a client, this disconnects from the host.
+
+---
+
 ## Screenshots and Visualization
 
 ### capture_screenshot

--- a/server/tools.ts
+++ b/server/tools.ts
@@ -5,6 +5,7 @@
 import "./tools/animation";
 import "./tools/camera";
 import "./tools/cubes";
+import "./tools/edit_session";
 import "./tools/element";
 import "./tools/import";
 import "./tools/mesh";

--- a/server/tools/edit_session.ts
+++ b/server/tools/edit_session.ts
@@ -1,0 +1,351 @@
+/// <reference types="three" />
+/// <reference types="blockbench-types" />
+import { z } from "zod";
+import { createTool } from "@/lib/factories";
+import { STATUS_EXPERIMENTAL } from "@/lib/constants";
+
+/**
+ * Check if an Edit Session is active
+ */
+function getActiveEditSession(): EditSession | null {
+  if (!Project || !Project.EditSession || !Project.EditSession.active) {
+    return null;
+  }
+  return Project.EditSession;
+}
+
+/**
+ * Send a custom command through the Edit Session
+ */
+createTool(
+  "edit_session_send_command",
+  {
+    description:
+      "Send a custom command through an active Edit Session. The command will be broadcast to all connected clients in the session. Requires an active Edit Session.",
+    annotations: {
+      title: "Edit Session: Send Command",
+      destructiveHint: true,
+      openWorldHint: true,
+    },
+    parameters: z.object({
+      command: z
+        .enum(["undo", "redo", "quit_session"])
+        .describe(
+          "The command to send. 'undo' undoes the last action, 'redo' redoes the last undone action, 'quit_session' closes the session for all clients."
+        ),
+    }),
+    async execute({ command }) {
+      const session = getActiveEditSession();
+
+      if (!session) {
+        throw new Error(
+          "No active Edit Session. Start or join an Edit Session first."
+        );
+      }
+
+      if (!session.hosting) {
+        throw new Error(
+          "Only the host can send commands. This client is not hosting the session."
+        );
+      }
+
+      session.sendAll("command", command);
+
+      return `Command "${command}" sent to all clients in the Edit Session.`;
+    },
+  },
+  STATUS_EXPERIMENTAL
+);
+
+/**
+ * Send custom data through the Edit Session
+ */
+createTool(
+  "edit_session_send_data",
+  {
+    description:
+      "Send custom data through an active Edit Session with a specified type. The data will be broadcast to all connected clients. Requires an active Edit Session and host privileges.",
+    annotations: {
+      title: "Edit Session: Send Custom Data",
+      destructiveHint: true,
+      openWorldHint: true,
+    },
+    parameters: z.object({
+      type: z
+        .string()
+        .describe(
+          "The type identifier for the data being sent (e.g., 'custom_action', 'mcp_command')"
+        ),
+      data: z
+        .any()
+        .describe(
+          "The data payload to send. Can be any JSON-serializable value (string, number, object, array, etc.)"
+        ),
+    }),
+    async execute({ type, data }) {
+      const session = getActiveEditSession();
+
+      if (!session) {
+        throw new Error(
+          "No active Edit Session. Start or join an Edit Session first."
+        );
+      }
+
+      if (!session.hosting) {
+        throw new Error(
+          "Only the host can send data. This client is not hosting the session."
+        );
+      }
+
+      const reservedTypes = [
+        "edit",
+        "init_model",
+        "command",
+        "chat_message",
+        "chat_input",
+        "client_count",
+        "change_project_meta",
+      ];
+      if (reservedTypes.includes(type)) {
+        throw new Error(
+          `Type "${type}" is reserved by Blockbench. Please use a custom type identifier.`
+        );
+      }
+
+      session.sendAll(type, data);
+
+      return `Custom data sent to all clients in the Edit Session. Type: "${type}"`;
+    },
+  },
+  STATUS_EXPERIMENTAL
+);
+
+/**
+ * Get Edit Session status
+ */
+createTool(
+  "edit_session_status",
+  {
+    description:
+      "Get the current status of the Edit Session, including whether a session is active, hosting status, client count, and session token.",
+    annotations: {
+      title: "Edit Session: Get Status",
+      destructiveHint: false,
+      openWorldHint: false,
+    },
+    parameters: z.object({}),
+    async execute() {
+      const session = getActiveEditSession();
+
+      if (!session) {
+        return {
+          active: false,
+          message: "No active Edit Session.",
+        };
+      }
+
+      return {
+        active: session.active,
+        hosting: session.hosting,
+        client_count: session.client_count,
+        token: session.token || null,
+        username: session.username || null,
+        has_project: !!session.Project,
+      };
+    },
+  },
+  STATUS_EXPERIMENTAL
+);
+
+/**
+ * Start an Edit Session
+ */
+createTool(
+  "edit_session_start",
+  {
+    description:
+      "Start a new Edit Session as the host. This creates a P2P connection that other users can join. Returns the session token that others can use to join.",
+    annotations: {
+      title: "Edit Session: Start (Host)",
+      destructiveHint: false,
+      openWorldHint: true,
+    },
+    parameters: z.object({
+      username: z
+        .string()
+        .optional()
+        .describe("Username to use in the session. If not provided, a random name will be assigned."),
+    }),
+    async execute({ username }) {
+      if (!Project) {
+        throw new Error(
+          "No project is open. Create or open a project before starting an Edit Session."
+        );
+      }
+
+      const existingSession = getActiveEditSession();
+      if (existingSession) {
+        throw new Error(
+          `An Edit Session is already active. Token: ${existingSession.token}`
+        );
+      }
+
+      const session = new EditSession();
+      
+      return new Promise((resolve, reject) => {
+        session.start(username);
+        
+        const checkToken = setInterval(() => {
+          if (session.token) {
+            clearInterval(checkToken);
+            resolve({
+              success: true,
+              token: session.token,
+              username: session.username,
+              message: `Edit Session started. Share this token with others to let them join: ${session.token}`,
+            });
+          }
+        }, 100);
+        
+        setTimeout(() => {
+          clearInterval(checkToken);
+          if (!session.token) {
+            reject(new Error("Failed to start Edit Session: timeout waiting for token"));
+          }
+        }, 10000);
+      });
+    },
+  },
+  STATUS_EXPERIMENTAL
+);
+
+/**
+ * Join an Edit Session
+ */
+createTool(
+  "edit_session_join",
+  {
+    description:
+      "Join an existing Edit Session using a token. This connects to a host's session as a client.",
+    annotations: {
+      title: "Edit Session: Join",
+      destructiveHint: true,
+      openWorldHint: true,
+    },
+    parameters: z.object({
+      token: z
+        .string()
+        .length(16)
+        .describe("The 16-character session token provided by the host"),
+      username: z
+        .string()
+        .optional()
+        .describe("Username to use in the session. If not provided, a random name will be assigned."),
+    }),
+    async execute({ token, username }) {
+      const existingSession = getActiveEditSession();
+      if (existingSession) {
+        throw new Error(
+          "An Edit Session is already active. Quit the current session before joining another."
+        );
+      }
+
+      const session = new EditSession();
+      
+      return new Promise((resolve, reject) => {
+        session.join(username || "", token);
+        
+        const checkActive = setInterval(() => {
+          if (session.active) {
+            clearInterval(checkActive);
+            resolve({
+              success: true,
+              token: session.token,
+              username: session.username,
+              hosting: session.hosting,
+              message: `Successfully joined Edit Session.`,
+            });
+          }
+        }, 100);
+        
+        setTimeout(() => {
+          clearInterval(checkActive);
+          if (!session.active) {
+            reject(new Error("Failed to join Edit Session: timeout or invalid token"));
+          }
+        }, 10000);
+      });
+    },
+  },
+  STATUS_EXPERIMENTAL
+);
+
+/**
+ * Quit the Edit Session
+ */
+createTool(
+  "edit_session_quit",
+  {
+    description:
+      "Quit the current Edit Session. If hosting, this will close the session for all clients. If joined as a client, this will disconnect from the host.",
+    annotations: {
+      title: "Edit Session: Quit",
+      destructiveHint: true,
+      openWorldHint: true,
+    },
+    parameters: z.object({}),
+    async execute() {
+      const session = getActiveEditSession();
+
+      if (!session) {
+        throw new Error("No active Edit Session to quit.");
+      }
+
+      const wasHosting = session.hosting;
+      session.quit();
+
+      if (wasHosting) {
+        return "Edit Session closed. All clients have been disconnected.";
+      } else {
+        return "Disconnected from Edit Session.";
+      }
+    },
+  },
+  STATUS_EXPERIMENTAL
+);
+
+/**
+ * Send a chat message through the Edit Session
+ */
+createTool(
+  "edit_session_send_chat",
+  {
+    description:
+      "Send a chat message through the Edit Session. The message will be visible to all connected clients in the chat panel.",
+    annotations: {
+      title: "Edit Session: Send Chat Message",
+      destructiveHint: false,
+      openWorldHint: false,
+    },
+    parameters: z.object({
+      message: z
+        .string()
+        .max(512)
+        .describe("The chat message to send (max 512 characters)"),
+    }),
+    async execute({ message }) {
+      const session = getActiveEditSession();
+
+      if (!session) {
+        throw new Error(
+          "No active Edit Session. Start or join an Edit Session first."
+        );
+      }
+
+      session.sendChat(message);
+
+      return `Chat message sent: "${message}"`;
+    },
+  },
+  STATUS_EXPERIMENTAL
+);


### PR DESCRIPTION
# Add Edit Session integration tools for MCP server

## Summary

This PR adds 7 new MCP tools that enable external control of Blockbench's Edit Session (P2P collaboration) feature. The MCP server can now programmatically start/join sessions, send commands and custom data through the Peer.js connection, and manage collaborative workflows remotely.

**New Tools:**
- `edit_session_start` - Start a new session as host
- `edit_session_join` - Join an existing session with a token  
- `edit_session_status` - Get current session status
- `edit_session_send_command` - Send commands (undo/redo/quit) to all clients
- `edit_session_send_data` - Send custom data through the P2P connection
- `edit_session_send_chat` - Send chat messages to participants
- `edit_session_quit` - Leave or close the session

All tools are marked as experimental. Documentation has been added to README.md and docs/tools.md.

## Review & Testing Checklist for Human

**⚠️ This PR has not been tested in a real Blockbench environment.** Please test thoroughly:

- [ ] **End-to-end testing** - Start Blockbench, create a project, and test `edit_session_start`. Verify you receive a valid token and can copy it.
- [ ] **Multi-client testing** - Open two Blockbench instances. Start a session in one, join from the other using `edit_session_join`. Verify both instances connect and sync.
- [ ] **Send operations** - In the host instance, use `edit_session_send_command` (try undo/redo) and `edit_session_send_data` (custom type). Verify commands execute on client and data is received.
- [ ] **Async timing** - The start/join tools use polling (100ms intervals, 10s timeout) to wait for session initialization. Verify this works reliably, or consider refactoring to use event callbacks if available in the EditSession API.
- [ ] **Error handling** - Test error cases: starting without a project, joining with invalid token, sending data when not hosting, using reserved type names in send_data.

### Recommended Test Plan

1. Load the plugin in Blockbench desktop app
2. Create or open a project  
3. Use an MCP client (Claude Desktop, VS Code, or MCP Inspector) to call `edit_session_start`
4. Copy the returned token
5. Open a second Blockbench instance and call `edit_session_join` with the token
6. Verify both instances show the same model
7. From the host, call `edit_session_send_command` with "undo"
8. Verify the undo action executes on the client instance
9. Test `edit_session_send_data` with custom data and verify it can be received by clients

### Notes

- The implementation wraps Blockbench's existing EditSession class, which uses Peer.js for P2P connections
- Reserved type names are validated in `send_data` to prevent conflicts with Blockbench's internal message types
- All tools check for active sessions and host privileges where required
- The polling approach in start/join may need refinement based on testing results

---

**Link to Devin run:** https://app.devin.ai/sessions/c1d3293212044423a1c4f397c7a449a8  
**Requested by:** Jason (im@jasongardner.co), GitHub: @jasonjgardner