### PR TITLE
refactor: improve tool factory type safety and fix texture handling

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,6 @@
 /// <reference types="blockbench-types" />
 import { VERSION } from "@/lib/constants";
 import { createServer } from "@/server/server";
-// Import tools from the tools module which re-exports from factories after registration
 import { tools, prompts, getToolCount } from "@/server/tools";
 import { registerToolsOnServer, registerResourcesOnServer } from "@/lib/factories";
 import { resources } from "@/server";
@@ -27,7 +26,7 @@ BBPlugin.register("mcp", {
   title: "MCP Server",
   author: "Jason J. Gardner",
   description: "Plugin to run an MCP server inside Blockbench.",
-  tags: ["MCP", "Server", "Protocol"],
+  tags: ["MCP", "AI"],
   icon: "settings_ethernet",
   variant: "both",
   async onload() {
@@ -314,11 +313,11 @@ BBPlugin.register("mcp", {
       }
     });
 
-    httpServer.listen(port, () => {
+    httpServer?.listen(port, () => {
       console.log(`[MCP] Server listening on http://localhost:${port}${endpoint}`);
     });
 
-    httpServer.on("error", (err: Error) => {
+    httpServer?.on("error", (err: Error) => {
       console.error("[MCP] Server error:", err);
       Blockbench.showQuickMessage(`MCP Server error: ${err.message}`, 3000);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockbench-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Blockbench MCP server plugin",
   "keywords": [
     "Blockbench",

--- a/server/tools/texture.ts
+++ b/server/tools/texture.ts
@@ -125,22 +125,28 @@ createTool(
         texture.load();
         texture.fillParticle();
         texture.layers_enabled = false;
-      } else if (fill_color) {
-        const color = Array.isArray(fill_color)
-          ? tinycolor({
-            r: Number(fill_color[0]),
-            g: Number(fill_color[1]),
-            b: Number(fill_color[2]),
-            a: Number(fill_color[3] ?? 255),
-          })
-          : tinycolor(fill_color);
+      } else {
         const { ctx } = texture.getActiveCanvas();
 
-        ctx.fillStyle = color.toRgbString().toLowerCase();
-        ctx.fillRect(0, 0, texture.width, texture.height);
+        if (fill_color) {
+          const color = Array.isArray(fill_color)
+            // @ts-ignore - tinycolor is available globally in Blockbench
+            ? tinycolor({
+              r: Number(fill_color[0]),
+              g: Number(fill_color[1]),
+              b: Number(fill_color[2]),
+              a: Number(fill_color[3] ?? 255),
+            })
+            // @ts-ignore - tinycolor ok
+            : tinycolor(fill_color);
+
+          ctx.fillStyle = color.toRgbString().toLowerCase();
+          ctx.fillRect(0, 0, texture.width, texture.height);
+        } else {
+          ctx.clearRect(0, 0, texture.width, texture.height);
+        }
 
         texture.updateSource(ctx.canvas.toDataURL("image/png", 1));
-
         texture.updateLayerChanges(true);
       }
 
@@ -259,7 +265,7 @@ createTool(
 
         textureList.forEach((texture) => {
           texture?.extend({
-            group: textureGroup,
+            group: textureGroup.uuid,
           });
         });
       }
@@ -278,8 +284,7 @@ createTool(
   {
     description: "Returns a list of all textures in the Blockbench editor.",
     annotations: {
-      title: "List Textures",
-      readOnlyHint: true,
+      title: "List Textures"
     },
     parameters: z.object({}),
     async execute() {
@@ -304,8 +309,7 @@ createTool(
     description:
       "Returns the image data of the given texture or default texture.",
     annotations: {
-      title: "Get Texture",
-      readOnlyHint: true,
+      title: "Get Texture"
     },
     parameters: z.object({
       texture: z.string().optional().describe("Texture ID or name."),


### PR DESCRIPTION
Enhanced tool factory to properly handle ZodEffects schemas from .refine() validation, enabling better input validation. Fixed texture operations and cleaned up annotations.

Changes:
- Add extractShape() to unwrap ZodEffects and ZodObject schemas using _def.typeName
- Update createTool() signature to accept generic ZodType instead of ZodRawShape
- Add TypeScript types for tool content (TextContent, ImageContent, ToolContentItem

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Tool factory improvements**
> 
> - Add `extractShape()` to unwrap `ZodEffects`/`ZodObject` and derive `inputSchema`
> - Update `createTool()` to accept generic `z.ZodType` and return `ToolResult`; store/registry now use extracted `inputSchema`
> - Introduce types `TextContent`, `ImageContent`, `ToolContentItem`, and `ToolResult`
> 
> **Texture tools fixes**
> 
> - `create_texture`: when no `fill_color`, canvas is cleared (instead of left unchanged); fill path uses `tinycolor` and updates source/layer changes
> - `add_texture_group`: assign `group` via `textureGroup.uuid` instead of the object reference
> - Cleanup annotations (remove read-only hints) for texture tools
> 
> **Server/UI**
> 
> - Use optional chaining for `httpServer.listen`/`on("error")`; update plugin tags to `"MCP", "AI"`
> 
> **Meta**
> 
> - Bump version to `1.3.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68085c9c658ed8d2b93d118bc15a28c3fa2b74d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->