### PR TITLE
feat: Add DeepWiki badge to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for improving the Blockbench MCP plugin. This project uses TypeScript and Bun. Please keep changes focused, documented, and easy to verify inside Blockbench.
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/jasonjgardner/blockbench-mcp-plugin)
+
 ## Prerequisites
 - Bun installed: https://bun.sh/
 - Blockbench (desktop) for local testing.


### PR DESCRIPTION
Added a badge link to DeepWiki for the Blockbench MCP plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a badge link to the contributing guidelines for improved navigation and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->