### PR TITLE
fix: send real MCP ping and reset inactivity timeout on pong (#37)

### DIFF
--- a/lib/sessions.ts
+++ b/lib/sessions.ts
@@ -136,6 +136,8 @@ class SessionManager {
     if (session) {
       session.lastPongAt = new Date();
       session.failedPings = 0;
+      // Reset inactivity timeout — a pong confirms the client is alive
+      this.resetTimeout(session);
     }
   }
 

--- a/server/net.ts
+++ b/server/net.ts
@@ -68,17 +68,21 @@ export default function createNetServer (
     sessionManager.configure(sessionConfig)
   }
 
-  // Set up ping callback for session keep-alive
-  // Note: The MCP SDK doesn't expose a direct ping method on the server-side,
-  // so we verify the session is still registered. The actual connection health
-  // is maintained through TCP keep-alive and the inactivity timeout.
+  // Set up ping callback for session keep-alive.
+  // Sends a real MCP ping request to the client to verify the connection is alive.
   sessionManager.setPingCallback(async (sessionId: string) => {
     const session = sessionTransports.get(sessionId)
     if (!session) return false
 
-    // Session exists and transport is available - consider it healthy
-    // TCP keep-alive and inactivity timeouts handle actual connection failures
-    return true
+    try {
+      // Use the underlying Server's ping() method to send a JSON-RPC ping
+      // and wait for the client's response (pong).
+      await session.server.server.ping()
+      return true
+    } catch {
+      // Ping failed — transport is likely dead
+      return false
+    }
   })
 
   // Register callback to close transport when sessionManager removes a session (e.g., timeout)


### PR DESCRIPTION
Fixes #37 — MCP clients (Codex, Roo, etc.) lose connection after idle periods because the server's ping mechanism was a no-op and pong responses did not reset the inactivity timeout.

1. **Ping callback was a no-op** — `server/net.ts` only checked if the session existed in the map, never actually sending an MCP ping to the client.
2. **Pong did not reset inactivity timeout** — `lib/sessions.ts` `recordPongReceived()` only cleared `failedPings` but never called `resetTimeout()`, so sessions were still terminated after 5 minutes of inactivity even when the client was alive and responding to pings.

- Replaced the no-op ping callback with a real MCP ping using `session.server.server.ping()` (the underlying `Server` class's `ping()` method that sends a JSON-RPC ping request and waits for the client's response).

- Added `this.resetTimeout(session)` to `recordPongReceived()` so that a successful pong resets the inactivity timer, preventing false session expiration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session keep-alive reliability by implementing actual health checks instead of existence verification.
  * Enhanced session timeout management to properly extend inactivity timeouts when receiving ping responses, preventing unexpected disconnections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->