### PR TITLE
fix: await async codec.compile in export_model

### DIFF
--- a/server/tools/export.ts
+++ b/server/tools/export.ts
@@ -165,7 +165,8 @@ export function registerExportTools() {
           id?: string;
           name?: string;
           extension?: string;
-          compile?: (opts?: unknown) => unknown;
+          // Some codecs (e.g. glTF) return a Promise from compile().
+          compile?: (opts?: unknown) => unknown | Promise<unknown>;
           getExportOptions?: () => Record<string, unknown>;
           fileName?: () => string;
         }
@@ -201,7 +202,9 @@ export function registerExportTools() {
           ? codec.getExportOptions()
           : undefined);
 
-      const rawResult = codec.compile(effectiveOptions);
+      // Await so async codecs (glTF/etc.) resolve before we stringify/write.
+      // Sync codecs (obj, bedrock, project) pass through via Promise.resolve.
+      const rawResult = await Promise.resolve(codec.compile(effectiveOptions));
 
       const isArrayBuffer = rawResult instanceof ArrayBuffer;
       const isBinaryView =


### PR DESCRIPTION
## Summary
`export_model` did not await `codec.compile()`. For async codecs (e.g. glTF),
the unresolved Promise was stringified as `"{}"`.

**Before:** `export_model(codec_id: "gltf")` → content `"{}"`  
**After:** same call → real glTF JSON (non-empty, includes `asset.generator`)

Sync codecs that already return strings continue to work via `Promise.resolve`.

## Test plan
- [x] `bun run build` + load `dist/mcp.js`
- [x] glTF export no longer returns `"{}"`
- [x] Spot-check a sync codec (e.g. `obj`) still exports


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model exports for codecs that compile asynchronously.
  * Exported content is now fully processed and serialized before completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->